### PR TITLE
Lsj/distinct orderby

### DIFF
--- a/src/com/holub/database/ConcreteTable.java
+++ b/src/com/holub/database/ConcreteTable.java
@@ -600,6 +600,9 @@ import com.holub.tools.ArrayIterator;
 		if(queryOptions.isDistinct()) {
 			resultTable = distinct(resultTable);
 		}
+		if(queryOptions.isOrderBy()) {
+			resultTable = orderBy(resultTable, queryOptions.getOrderByColumns());
+		}
 
 		return new UnmodifiableTable(resultTable);
 	}
@@ -633,6 +636,18 @@ import com.holub.tools.ArrayIterator;
 				resultTable.insert(currentRow.cloneRow());
 			}
 		}
+		return resultTable;
+	}
+
+	private Table orderBy(Table table, List orderByColumns) {
+		ArrayList<String> cols = new ArrayList<>();
+		for(int i = 0; i < table.rows().columnCount(); i++) {
+			cols.add(table.rows().columnName(i));
+		}
+		String[] copyColumnNames = cols.toArray(new String[cols.size()]);
+
+		Table resultTable = new ConcreteTable(null, copyColumnNames);
+
 		return resultTable;
 	}
 

--- a/src/com/holub/database/ConcreteTable.java
+++ b/src/com/holub/database/ConcreteTable.java
@@ -94,6 +94,7 @@ import com.holub.tools.ArrayIterator;
 
 	// @simple-construction-end
 	//
+
 	/**********************************************************************
 	 * Create a table using an importer. See {@link CSVImporter} for an example.
 	 */
@@ -611,12 +612,25 @@ import com.holub.tools.ArrayIterator;
 		String[] copyColumnNames = cols.toArray(new String[cols.size()]);
 
 		Table resultTable = new ConcreteTable(null, copyColumnNames);
-		Set<Results> uniqueRows = new HashSet<>();
+
+		ArrayList<Object[]> uniqueRows = new ArrayList<>();
 		Results currentRow = (Results) table.rows();
 
 		while (currentRow.advance()) {
-			if(uniqueRows.add(currentRow)) {
-				resultTable.insert((Object[]) currentRow.cloneRow());
+			boolean isDuplicate = false;
+			for(int i = 0; i < uniqueRows.size(); i++) {
+				for (int j = 0; j < currentRow.columnCount(); j++) {
+					if (!uniqueRows.get(i)[j].equals(currentRow.column(copyColumnNames[j])))
+						break;
+					if (j == currentRow.columnCount() - 1)
+						isDuplicate = true;
+				}
+				if(isDuplicate)
+					break;
+			}
+			if(!isDuplicate) {
+				uniqueRows.add(currentRow.cloneRow());
+				resultTable.insert(currentRow.cloneRow());
 			}
 		}
 		return resultTable;

--- a/src/com/holub/database/ConcreteTable.java
+++ b/src/com/holub/database/ConcreteTable.java
@@ -416,7 +416,7 @@ import com.holub.tools.ArrayIterator;
 			if (where.approve(envelope))
 				resultTable.insert((Object[]) currentRow.cloneRow());
 		}
-		return new UnmodifiableTable(resultTable);
+		return resultTable;
 	}
 
 	// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -438,7 +438,7 @@ import com.holub.tools.ArrayIterator;
 				resultTable.insert(newRow);
 			}
 		}
-		return new UnmodifiableTable(resultTable);
+		return resultTable;
 	}
 
 	/**
@@ -481,7 +481,7 @@ import com.holub.tools.ArrayIterator;
 
 		selectFromCartesianProduct(0, where, requestedColumns, allTables, envelope, resultTable);
 
-		return new UnmodifiableTable(resultTable);
+		return resultTable;
 	}
 
 	/**
@@ -591,6 +591,35 @@ import com.holub.tools.ArrayIterator;
 	// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 	public Table select(Selector where, Collection requestedColumns) {
 		return select(where, requestedColumns, null);
+	}
+
+	public Table select(Selector where, Collection requestedColumns, Collection other, QueryOptions queryOptions) {
+		Table resultTable = select(where, requestedColumns, other);
+
+		if(queryOptions.isDistinct()) {
+			resultTable = distinct(resultTable);
+		}
+
+		return new UnmodifiableTable(resultTable);
+	}
+
+	private Table distinct(Table table) {
+		ArrayList<String> cols = new ArrayList<>();
+		for(int i = 0; i < table.rows().columnCount(); i++) {
+			cols.add(table.rows().columnName(i));
+		}
+		String[] copyColumnNames = cols.toArray(new String[cols.size()]);
+
+		Table resultTable = new ConcreteTable(null, copyColumnNames);
+		Set<Results> uniqueRows = new HashSet<>();
+		Results currentRow = (Results) table.rows();
+
+		while (currentRow.advance()) {
+			if(uniqueRows.add(currentRow)) {
+				resultTable.insert((Object[]) currentRow.cloneRow());
+			}
+		}
+		return resultTable;
 	}
 
 	// @select-end

--- a/src/com/holub/database/ConcreteTable.java
+++ b/src/com/holub/database/ConcreteTable.java
@@ -646,8 +646,41 @@ import com.holub.tools.ArrayIterator;
 		}
 		String[] copyColumnNames = cols.toArray(new String[cols.size()]);
 
-		Table resultTable = new ConcreteTable(null, copyColumnNames);
+		int[] orderByColumnIndex = new int[orderByColumns.size()];
+		for(int i = 0; i < orderByColumns.size(); i++) {
+			for(int j = 0; j < copyColumnNames.length; j++) {
+				if (orderByColumns.get(i).equals(copyColumnNames[j])) {
+					orderByColumnIndex[i] = j;
+					break;
+				}
+			}
+		}
 
+		Table resultTable = new ConcreteTable(null, copyColumnNames);
+		LinkedList<Object[]> copyRowSet = new LinkedList<>();
+		Results copyRow = (Results) table.rows();
+
+		while(copyRow.advance()) {
+			copyRowSet.add(copyRow.cloneRow());
+		}
+
+		Comparator<Object[]> comparator = (o1, o2) -> {
+			for (int index : orderByColumnIndex) {
+				Comparable<Object> value1 = (Comparable<Object>) o1[index];
+				Comparable<Object> value2 = (Comparable<Object>) o2[index];
+				int result = value1.compareTo(value2);
+				if (result != 0) {
+					return result;
+				}
+			}
+			return 0;
+		};
+
+		copyRowSet.sort(comparator);
+
+		for (Object[] objects : copyRowSet) {
+			resultTable.insert(objects);
+		}
 		return resultTable;
 	}
 

--- a/src/com/holub/database/Database.java
+++ b/src/com/holub/database/Database.java
@@ -1446,7 +1446,7 @@ public final class Database
 			};
 
 		try
-		{	Table result = primary.select(selector, columns, participantsInJoin);
+		{	Table result = primary.select(selector, columns, participantsInJoin, queryOptions);
 
 			// If this is a "SELECT INTO <table>" request, remove the 
 			// returned table from the UnmodifiableTable wrapper, give

--- a/src/com/holub/database/Database.java
+++ b/src/com/holub/database/Database.java
@@ -818,6 +818,13 @@ public final class Database
 
 			Expression where = (in.matchAdvance(WHERE) == null)
 								? null : expr();
+
+			if( in.matchAdvance(ORDER_BY) != null )
+			{
+				queryOptions.setOrderBy();
+				queryOptions.setOrderByColumns(idList());
+			}
+
 			Table result = doSelect(columns, into,
 								requestedTableNames, where, queryOptions );
 			return result;

--- a/src/com/holub/database/QueryOptions.java
+++ b/src/com/holub/database/QueryOptions.java
@@ -1,0 +1,16 @@
+package com.holub.database;
+
+public class QueryOptions {
+    private boolean distinct = false;
+
+    public QueryOptions() {
+    }
+
+    public boolean isDistinct() {
+        return distinct;
+    }
+
+    public void setDistinct() {
+        this.distinct = true;
+    }
+}

--- a/src/com/holub/database/QueryOptions.java
+++ b/src/com/holub/database/QueryOptions.java
@@ -1,7 +1,12 @@
 package com.holub.database;
 
+import java.util.List;
+
 public class QueryOptions {
     private boolean distinct = false;
+    private boolean orderBy = false;
+
+    private List orderByColumns;
 
     public QueryOptions() {
     }
@@ -12,5 +17,21 @@ public class QueryOptions {
 
     public void setDistinct() {
         this.distinct = true;
+    }
+
+    public boolean isOrderBy() {
+        return orderBy;
+    }
+
+    public void setOrderBy() {
+        this.orderBy = true;
+    }
+
+    public List getOrderByColumns() {
+        return orderByColumns;
+    }
+
+    public void setOrderByColumns(List orderByColumns) {
+        this.orderByColumns = orderByColumns;
     }
 }

--- a/src/com/holub/database/Table.java
+++ b/src/com/holub/database/Table.java
@@ -240,6 +240,8 @@ public interface Table extends Serializable, Cloneable
 	 */
 	Table select(Selector where, Collection requestedColumns );
 
+	Table select(Selector where, Collection requestedColumns, Collection other, QueryOptions queryOptions);
+
 	/** Return an iterator across the rows of the current table.
 	 */
 	Cursor rows();

--- a/src/com/holub/database/UnmodifiableTable.java
+++ b/src/com/holub/database/UnmodifiableTable.java
@@ -95,6 +95,9 @@ public class UnmodifiableTable implements Table
 	public Table select(Selector w, Collection r)
 	{	return wrapped.select(w, r);
 	}
+	public Table select(Selector w, Collection r, Collection o, QueryOptions op)
+	{	return wrapped.select(w, r, o, op);
+	}
 	public Cursor rows()
 	{	return wrapped.rows();
 	}


### PR DESCRIPTION
#10 

Database 클래스의 statement 메소드에서
distinct와 order by 키워드를 읽을 경우
QueryOptions 클래스 객체에 옵션을 적용하는 식으로 옵션 설정
이어지는 doSelect 메소드에 QueryOptions 객체를 같이 넣는 식으로 수정

doSelect 메소드가 select 메소드를 호출할 때, QueryOptions를 같이 받게 하는 새로운 select 메소드 생성
해당 select 메소드에서 다른 select 메소드를 호출해 ConcreteTable 제작한 이후
그것을 distinct, order by 메소드로 가공 후 Unmodifiable로 감싸서 리턴

기존의 Unmodifiable로 감싸서 반환하던 select 메소드는 그냥 table만 반환하게 하고
마지막에서 감싸는 것으로 수정